### PR TITLE
Add Dependabot configuration and auto-merge workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,23 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+
+      - name: Auto-merge patch updates
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
This PR introduces automated dependency management by configuring Dependabot to check for updates and automatically merge patch-level dependency updates.

## Key Changes
- **Added `.github/dependabot.yml`**: Configures Dependabot to check for updates on a weekly schedule for both npm packages and GitHub Actions
- **Added `.github/workflows/dependabot-auto-merge.yml`**: Implements a GitHub Actions workflow that automatically merges Dependabot pull requests for patch-level version updates using squash commits

## Implementation Details
- Dependabot is configured to monitor two package ecosystems:
  - npm packages in the root directory
  - GitHub Actions workflows
- The auto-merge workflow only triggers on pull requests created by the Dependabot bot
- Auto-merge is limited to patch-level updates (`version-update:semver-patch`) to minimize risk, while minor and major updates require manual review
- Uses the `dependabot/fetch-metadata` action to determine update type and the GitHub CLI to perform the merge

https://claude.ai/code/session_015eM8TrfZfFbTW7iZ4H7BSs