### PR TITLE
Fix invisible View Site button on project pages

### DIFF
--- a/src/layouts/ProjectPost.astro
+++ b/src/layouts/ProjectPost.astro
@@ -77,7 +77,7 @@ const { title, description, pubDate, updatedDate, heroImage, siteUrl, repoUrl, t
 				opacity: 0.8;
 			}
 			.link-site {
-				background: rgb(var(--accent));
+				background: var(--accent);
 				color: white;
 			}
 			.link-repo {


### PR DESCRIPTION
## Summary
- The `.link-site` button on project pages was invisible because `background: rgb(var(--accent))` produces invalid CSS — `--accent` is a hex value (`#2337ff`), not RGB components
- Changed to `background: var(--accent)` so the blue background renders correctly, making the white button text visible

## Test plan
- [ ] Visit a project page (e.g. /projects/tokenbury) and confirm the "View Site" button is visible with a blue background