### PR TITLE
Add MCTS AI opponent to Ultimate Tic-Tac-Toe

### DIFF
--- a/src/components/arcade/ultimate-tic-tac-toe/components/Game.tsx
+++ b/src/components/arcade/ultimate-tic-tac-toe/components/Game.tsx
@@ -37,6 +37,12 @@ export function Game() {
         legalMoves={legalMoves}
         onMove={game.makeMove}
       />
+      <button
+        onClick={handleReset}
+        className="text-sm text-slate-500 hover:text-slate-300 transition-colors focus-visible:outline-2 focus-visible:outline-blue-400 focus-visible:outline-offset-2 rounded"
+      >
+        ← Menu
+      </button>
     </div>
   )
 }

--- a/src/components/arcade/ultimate-tic-tac-toe/components/Game.tsx
+++ b/src/components/arcade/ultimate-tic-tac-toe/components/Game.tsx
@@ -9,7 +9,8 @@ export function Game() {
   const game = useGame()
   const [gameStarted, setGameStarted] = useState(false)
 
-  const legalMoves = getLegalMoves(game.state)
+  const isHumanTurn = game.mode === 'two-player' || game.state.currentPlayer !== game.aiPlayer
+  const legalMoves = (isHumanTurn && !game.isAiThinking) ? getLegalMoves(game.state) : []
 
   const handleReset = () => {
     game.resetGame()
@@ -19,14 +20,18 @@ export function Game() {
   if (!gameStarted) {
     return (
       <div className="min-h-screen bg-slate-950 flex items-center justify-center">
-        <ModeSelector onStart={(mode) => { game.setMode(mode); setGameStarted(true) }} />
+        <ModeSelector onStart={(mode, iterations) => {
+          game.setMode(mode)
+          game.setAiIterations(iterations)
+          setGameStarted(true)
+        }} />
       </div>
     )
   }
 
   return (
     <div className="min-h-screen bg-slate-950 text-white flex flex-col items-center justify-center gap-6 p-6">
-      <StatusBar state={game.state} onReset={handleReset} />
+      <StatusBar state={game.state} onReset={handleReset} isAiThinking={game.isAiThinking} />
       <MetaBoard
         state={game.state}
         legalMoves={legalMoves}

--- a/src/components/arcade/ultimate-tic-tac-toe/components/ModeSelector.tsx
+++ b/src/components/arcade/ultimate-tic-tac-toe/components/ModeSelector.tsx
@@ -2,13 +2,15 @@ import { clsx } from 'clsx'
 import { useState } from 'react'
 
 interface ModeSelectorProps {
-  onStart: (mode: 'two-player' | 'vs-ai') => void
+  onStart: (mode: 'two-player' | 'vs-ai', iterations: number) => void
 }
 
 const DIFFICULTY_LABELS = ['Easy', 'Medium', 'Hard', 'Expert']
+const DIFFICULTY_ITERATIONS = [500, 2000, 8000, 25000]
 
 export function ModeSelector({ onStart }: ModeSelectorProps) {
   const [selectedMode, setSelectedMode] = useState<'two-player' | 'vs-ai'>('two-player')
+  const [difficultyIdx, setDifficultyIdx] = useState<number>(1)
 
   return (
     <div className="flex flex-col items-center gap-8 px-6 py-12">
@@ -31,18 +33,34 @@ export function ModeSelector({ onStart }: ModeSelectorProps) {
           Two Player
         </button>
         <button
-          disabled
-          title="AI coming soon"
-          className="px-6 py-3 rounded-lg font-semibold bg-slate-800 text-slate-500 cursor-not-allowed"
+          onClick={() => setSelectedMode('vs-ai')}
+          className={clsx(
+            'px-6 py-3 rounded-lg font-semibold transition-colors cursor-pointer',
+            'focus-visible:outline-2 focus-visible:outline-blue-400 focus-visible:outline-offset-2',
+            selectedMode === 'vs-ai'
+              ? 'bg-blue-600 text-white'
+              : 'bg-slate-700 text-slate-300 hover:bg-slate-600',
+          )}
         >
-          vs AI{' '}
-          <span className="text-xs font-normal">(coming soon)</span>
+          vs AI
         </button>
       </div>
 
-      <div className="w-full max-w-xs opacity-40 pointer-events-none select-none">
-        <p className="text-sm text-slate-400 mb-2 text-center">AI Difficulty</p>
-        <input type="range" min={0} max={3} defaultValue={1} disabled className="w-full" />
+      <div className={clsx('w-full max-w-xs', selectedMode !== 'vs-ai' && 'opacity-40 pointer-events-none select-none')}>
+        <p className="text-sm text-slate-400 mb-2 text-center">
+          AI Difficulty
+          {selectedMode === 'vs-ai' && (
+            <span className="ml-2 font-semibold text-slate-200">{DIFFICULTY_LABELS[difficultyIdx]}</span>
+          )}
+        </p>
+        <input
+          type="range"
+          min={0}
+          max={3}
+          value={difficultyIdx}
+          onChange={(e) => setDifficultyIdx(Number(e.target.value))}
+          className="w-full cursor-pointer"
+        />
         <div className="flex justify-between text-xs text-slate-500 mt-1">
           {DIFFICULTY_LABELS.map(label => (
             <span key={label}>{label}</span>
@@ -51,7 +69,7 @@ export function ModeSelector({ onStart }: ModeSelectorProps) {
       </div>
 
       <button
-        onClick={() => onStart(selectedMode)}
+        onClick={() => onStart(selectedMode, DIFFICULTY_ITERATIONS[difficultyIdx])}
         className="px-10 py-3 bg-blue-600 hover:bg-blue-500 rounded-xl font-bold text-lg text-white transition-colors focus-visible:outline-2 focus-visible:outline-blue-400 focus-visible:outline-offset-2 cursor-pointer"
       >
         Start Game

--- a/src/components/arcade/ultimate-tic-tac-toe/components/StatusBar.tsx
+++ b/src/components/arcade/ultimate-tic-tac-toe/components/StatusBar.tsx
@@ -4,25 +4,33 @@ import type { GameState } from '../game/gameLogic'
 interface StatusBarProps {
   state: GameState
   onReset: () => void
+  isAiThinking: boolean
 }
 
-export function StatusBar({ state, onReset }: StatusBarProps) {
+export function StatusBar({ state, onReset, isAiThinking }: StatusBarProps) {
   const { gameResult, currentPlayer } = state
 
   return (
     <div aria-live="polite" className="text-center min-h-[4rem] flex flex-col items-center justify-center gap-3">
       {gameResult === null ? (
-        <p className="text-lg font-semibold text-slate-200">
-          <span
-            className={clsx(
-              'font-black text-xl',
-              currentPlayer === 'X' ? 'text-emerald-400' : 'text-rose-400',
-            )}
-          >
-            {currentPlayer}
-          </span>
-          {''}'s turn
-        </p>
+        isAiThinking ? (
+          <p className="text-lg font-semibold text-slate-400 flex items-center gap-2">
+            <span className="inline-block w-2.5 h-2.5 rounded-full bg-rose-400 animate-pulse" />
+            AI is thinking...
+          </p>
+        ) : (
+          <p className="text-lg font-semibold text-slate-200">
+            <span
+              className={clsx(
+                'font-black text-xl',
+                currentPlayer === 'X' ? 'text-emerald-400' : 'text-rose-400',
+              )}
+            >
+              {currentPlayer}
+            </span>
+            {''}'s turn
+          </p>
+        )
       ) : (
         <>
           <p className="text-xl font-bold text-white">

--- a/src/components/arcade/ultimate-tic-tac-toe/game/mcts.worker.ts
+++ b/src/components/arcade/ultimate-tic-tac-toe/game/mcts.worker.ts
@@ -1,0 +1,132 @@
+declare const self: DedicatedWorkerGlobalScope
+
+import {
+  type GameState,
+  type BoardResult,
+  type Player,
+  getLegalMoves,
+  applyMove,
+  isTerminal,
+  getWinner,
+} from './gameLogic'
+
+interface MCTSNode {
+  state: GameState
+  move: [number, number] | null
+  parent: MCTSNode | null
+  children: MCTSNode[]
+  wins: number
+  visits: number
+  untriedMoves: Array<[number, number]>
+}
+
+const C = Math.SQRT2
+
+function bestUcb1Child(node: MCTSNode): MCTSNode {
+  let best = node.children[0]
+  let bestScore = -Infinity
+  const logParentVisits = Math.log(node.visits)
+  for (const child of node.children) {
+    const score = child.wins / child.visits + C * Math.sqrt(logParentVisits / child.visits)
+    if (score > bestScore) {
+      bestScore = score
+      best = child
+    }
+  }
+  return best
+}
+
+function simulate(state: GameState): BoardResult {
+  let s = state
+  while (!isTerminal(s)) {
+    const moves = getLegalMoves(s)
+    const [b, c] = moves[Math.floor(Math.random() * moves.length)]
+    s = applyMove(s, b, c)
+  }
+  return getWinner(s)
+}
+
+function backpropagate(node: MCTSNode, result: BoardResult): void {
+  let current: MCTSNode | null = node
+  while (current !== null) {
+    current.visits++
+    if (current.move !== null) {
+      // applyMove toggles currentPlayer, so the mover into this node is the opposite
+      const mover: Player = current.state.currentPlayer === 'X' ? 'O' : 'X'
+      if (result === mover) {
+        current.wins += 1
+      } else if (result === 'draw') {
+        current.wins += 0.5
+      }
+    }
+    current = current.parent
+  }
+}
+
+export function mcts(rootState: GameState, iterations: number): [number, number] {
+  const root: MCTSNode = {
+    state: rootState,
+    move: null,
+    parent: null,
+    children: [],
+    wins: 0,
+    visits: 0,
+    untriedMoves: getLegalMoves(rootState),
+  }
+
+  for (let i = 0; i < iterations; i++) {
+    // 1. Selection
+    let node = root
+    while (node.untriedMoves.length === 0 && node.children.length > 0) {
+      node = bestUcb1Child(node)
+    }
+
+    // 2. Expansion
+    if (node.untriedMoves.length > 0 && !isTerminal(node.state)) {
+      const idx = Math.floor(Math.random() * node.untriedMoves.length)
+      const [boardIdx, cellIdx] = node.untriedMoves.splice(idx, 1)[0]
+      const newState = applyMove(node.state, boardIdx, cellIdx)
+      const child: MCTSNode = {
+        state: newState,
+        move: [boardIdx, cellIdx],
+        parent: node,
+        children: [],
+        wins: 0,
+        visits: 0,
+        untriedMoves: getLegalMoves(newState),
+      }
+      node.children.push(child)
+      node = child
+    }
+
+    // 3. Simulation
+    const result = simulate(node.state)
+
+    // 4. Backpropagation
+    backpropagate(node, result)
+  }
+
+  // Return the child of root with the highest visit count
+  if (root.children.length === 0) {
+    // Fallback: shouldn't happen for a non-terminal state, but be safe
+    const moves = getLegalMoves(rootState)
+    return moves[Math.floor(Math.random() * moves.length)]
+  }
+
+  let best = root.children[0]
+  for (const child of root.children) {
+    if (child.visits > best.visits) best = child
+  }
+  return best.move!
+}
+
+self.onmessage = (e: MessageEvent<{ state: GameState; iterations: number }>) => {
+  const { state, iterations } = e.data
+  const t0 = performance.now()
+  const move = mcts(state, iterations)
+  self.postMessage({
+    move,
+    iterations,
+    timeMs: Math.round(performance.now() - t0),
+  })
+}

--- a/src/components/arcade/ultimate-tic-tac-toe/hooks/useGame.ts
+++ b/src/components/arcade/ultimate-tic-tac-toe/hooks/useGame.ts
@@ -1,10 +1,11 @@
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useEffect, useRef } from 'react'
 import {
   type GameState,
   type Player,
   createInitialState,
   applyMove,
   getLegalMoves,
+  isTerminal,
 } from '../game/gameLogic'
 
 export interface UseGameReturn {
@@ -19,19 +20,69 @@ export interface UseGameReturn {
   setAiIterations: (n: number) => void
 }
 
+const AI_PLAYER: Player = 'O'
+
+function createWorker(): Worker {
+  return new Worker(new URL('../game/mcts.worker.ts', import.meta.url), { type: 'module' })
+}
+
 export function useGame(): UseGameReturn {
   const [state, setState] = useState<GameState>(createInitialState)
   const [mode, setModeState] = useState<'two-player' | 'vs-ai'>('two-player')
+  const [aiIterations, setAiIterationsState] = useState<number>(2000)
+  const [isAiThinking, setIsAiThinking] = useState<boolean>(false)
+  const workerRef = useRef<Worker | null>(null)
+
+  useEffect(() => {
+    workerRef.current = createWorker()
+    return () => {
+      workerRef.current?.terminate()
+    }
+  }, [])
+
+  // Trigger AI move when it becomes the AI's turn
+  useEffect(() => {
+    if (
+      mode !== 'vs-ai' ||
+      state.currentPlayer !== AI_PLAYER ||
+      isTerminal(state) ||
+      isAiThinking
+    ) return
+
+    const worker = workerRef.current
+    if (!worker) return
+
+    setIsAiThinking(true)
+
+    worker.onmessage = (e: MessageEvent<{ move: [number, number] }>) => {
+      const [b, c] = e.data.move
+      setState(prev => {
+        const legal = getLegalMoves(prev)
+        if (!legal.some(([lb, lc]) => lb === b && lc === c)) return prev
+        return applyMove(prev, b, c)
+      })
+      setIsAiThinking(false)
+    }
+
+    worker.postMessage({ state, iterations: aiIterations })
+  // aiIterations intentionally omitted: difficulty can't change mid-game in the current UI
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [state, mode, isAiThinking])
 
   const makeMove = useCallback((boardIdx: number, cellIdx: number) => {
+    if (isAiThinking) return
     setState(prev => {
       const legal = getLegalMoves(prev)
       if (!legal.some(([b, c]) => b === boardIdx && c === cellIdx)) return prev
       return applyMove(prev, boardIdx, cellIdx)
     })
-  }, [])
+  }, [isAiThinking])
 
   const resetGame = useCallback(() => {
+    // Terminate old worker to cancel any in-flight computation
+    workerRef.current?.terminate()
+    workerRef.current = createWorker()
+    setIsAiThinking(false)
     setState(createInitialState())
   }, [])
 
@@ -39,16 +90,16 @@ export function useGame(): UseGameReturn {
     setModeState(m)
   }, [])
 
-  const setAiIterations = useCallback((_n: number) => {
-    // placeholder — AI not implemented yet
+  const setAiIterations = useCallback((n: number) => {
+    setAiIterationsState(n)
   }, [])
 
   return {
     state,
     mode,
-    aiPlayer: 'O',
-    aiIterations: 500,
-    isAiThinking: false,
+    aiPlayer: AI_PLAYER,
+    aiIterations,
+    isAiThinking,
     makeMove,
     resetGame,
     setMode,


### PR DESCRIPTION
## Summary

- Implements UCT-variant Monte Carlo Tree Search running in a Web Worker, keeping the UI responsive during AI computation
- Backpropagation correctly tracks wins from the perspective of the player who made the move to reach each node; best move selected by visit count (not win rate)
- Four difficulty levels: Easy (500 iterations), Medium (2k), Hard (8k), Expert (25k)
- Worker is terminated and recreated on reset, cancelling any in-flight computation cleanly
- Adds a "← Menu" button in-game to return to the mode selector at any time

## Files changed

- **`game/mcts.worker.ts`** (new) — Full MCTS algorithm + Web Worker message handler
- **`hooks/useGame.ts`** — Worker lifecycle (mount/unmount/reset), AI trigger effect, real `isAiThinking` state
- **`components/ModeSelector.tsx`** — vs AI button enabled; difficulty slider wired up with current level label
- **`components/StatusBar.tsx`** — "AI is thinking..." indicator with `animate-pulse` dot
- **`components/Game.tsx`** — Disables cells on AI's turn; passes iterations from ModeSelector; "← Menu" button

## Test plan

- [ ] vs AI → Easy: AI responds quickly after each human move
- [ ] vs AI → Expert: main thread stays responsive while AI thinks (UI not blocked)
- [ ] Click "← Menu" mid-game: returns to mode selector, board resets, no stale AI move applied
- [ ] Two-player mode: `isAiThinking` never true, no auto-moves
- [ ] Build passes: `npm run build` with no errors

🤖 Generated with [Claude Code](https://claude.ai/claude-code)