### PR TITLE
Add Plausible custom event tracking to Ultimate Tic-Tac-Toe

### DIFF
--- a/src/components/arcade/ultimate-tic-tac-toe/components/Game.tsx
+++ b/src/components/arcade/ultimate-tic-tac-toe/components/Game.tsx
@@ -1,9 +1,10 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useGame } from '../hooks/useGame'
 import { getLegalMoves } from '../game/gameLogic'
 import { ModeSelector } from './ModeSelector'
 import { MetaBoard } from './MetaBoard'
 import { StatusBar } from './StatusBar'
+import { trackGameStart, trackGameQuit, trackGameComplete } from '../utils/analytics'
 
 export function Game() {
   const game = useGame()
@@ -12,7 +13,16 @@ export function Game() {
   const isHumanTurn = game.mode === 'two-player' || game.state.currentPlayer !== game.aiPlayer
   const legalMoves = (isHumanTurn && !game.isAiThinking) ? getLegalMoves(game.state) : []
 
+  useEffect(() => {
+    if (gameStarted && game.state.gameResult !== null) {
+      trackGameComplete(game.mode, game.aiIterations, game.state.gameResult)
+    }
+  }, [game.state.gameResult])
+
   const handleReset = () => {
+    if (gameStarted && game.state.gameResult === null) {
+      trackGameQuit(game.mode, game.aiIterations)
+    }
     game.resetGame()
     setGameStarted(false)
   }
@@ -23,6 +33,7 @@ export function Game() {
         <ModeSelector onStart={(mode, iterations) => {
           game.setMode(mode)
           game.setAiIterations(iterations)
+          trackGameStart(mode, iterations)
           setGameStarted(true)
         }} />
       </div>

--- a/src/components/arcade/ultimate-tic-tac-toe/utils/analytics.ts
+++ b/src/components/arcade/ultimate-tic-tac-toe/utils/analytics.ts
@@ -1,0 +1,41 @@
+declare global {
+  function plausible(eventName: string, options?: { props?: Record<string, string> }): void;
+}
+
+const DIFFICULTY_MAP: Record<number, string> = {
+  500: 'Easy',
+  2000: 'Medium',
+  8000: 'Hard',
+  25000: 'Expert',
+};
+
+function difficultyLabel(iterations: number): string {
+  return DIFFICULTY_MAP[iterations] ?? 'Unknown';
+}
+
+export function trackGameStart(mode: string, iterations: number) {
+  const props: Record<string, string> = { mode };
+  if (mode === 'vs-ai') props.difficulty = difficultyLabel(iterations);
+  window.plausible?.('UTTT: Game Start', { props });
+}
+
+export function trackGameQuit(mode: string, iterations: number) {
+  const props: Record<string, string> = { mode };
+  if (mode === 'vs-ai') props.difficulty = difficultyLabel(iterations);
+  window.plausible?.('UTTT: Game Quit', { props });
+}
+
+export function trackGameComplete(
+  mode: string,
+  iterations: number,
+  gameResult: 'X' | 'O' | 'draw',
+) {
+  const props: Record<string, string> = { mode };
+  if (mode === 'vs-ai') {
+    props.difficulty = difficultyLabel(iterations);
+    props.outcome = gameResult === 'X' ? 'win' : gameResult === 'O' ? 'lose' : 'draw';
+  } else {
+    props.result = gameResult === 'X' ? 'X wins' : gameResult === 'O' ? 'O wins' : 'draw';
+  }
+  window.plausible?.('UTTT: Game Complete', { props });
+}


### PR DESCRIPTION
## Summary

- Adds a `utils/analytics.ts` module with three tracking functions and a TypeScript declaration for `window.plausible`
- Fires `UTTT: Game Start` (with `mode` + `difficulty` for vs-AI) when a game begins
- Fires `UTTT: Game Quit` when the player returns to menu before the game ends
- Fires `UTTT: Game Complete` when the game ends — includes `result` (two-player) or `difficulty` + `outcome` (win/lose/draw from human's perspective) for vs-AI

## Test plan

- [ ] Start a two-player game → Network tab shows `UTTT: Game Start` POST with `mode=two-player`
- [ ] Return to menu mid-game → `UTTT: Game Quit` fires
- [ ] Play a full two-player game → `UTTT: Game Complete` with `result` prop
- [ ] Start a vs-AI game → `UTTT: Game Start` with `mode=vs-ai` and `difficulty`
- [ ] Win/lose an AI game → `UTTT: Game Complete` with `outcome=win` or `outcome=lose`
- [ ] Clicking Play Again after game ends does NOT fire `UTTT: Game Quit`
- [ ] Add goals in Plausible dashboard: `UTTT: Game Start`, `UTTT: Game Quit`, `UTTT: Game Complete`

🤖 Generated with [Claude Code](https://claude.com/claude-code)